### PR TITLE
Enable or disable cancel option when creating a team

### DIFF
--- a/app/src/main/java/com/sedilant/yambol/YambolApp.kt
+++ b/app/src/main/java/com/sedilant/yambol/YambolApp.kt
@@ -46,7 +46,7 @@ sealed interface YambolScreen {
     data object Login : YambolScreen
 
     @Serializable
-    data object CreateTeam : YambolScreen
+    data class CreateTeam(val isCancellable: Boolean) : YambolScreen
 
     @Serializable
     data class PlayerCardDetails(val id: Int?) : YambolScreen
@@ -121,8 +121,12 @@ fun YambolApp(
 
             composable<YambolScreen.Home> {
                 HomeScreen(
-                    onCreateTeam = {
-                        navController.navigate(YambolScreen.CreateTeam)
+                    onCreateTeam = { isCancellable ->
+                        navController.navigate(
+                            YambolScreen.CreateTeam(
+                                isCancellable = isCancellable
+                            )
+                        )
                     },
                     onLastTrainClick = { trainId ->
                         navController.navigate(
@@ -157,8 +161,11 @@ fun YambolApp(
                 ProfileScreen()
             }
 
-            composable<YambolScreen.CreateTeam> {
-                CreateTeamScreen {
+            composable<YambolScreen.CreateTeam> { navBackStackEntry ->
+                val args = navBackStackEntry.toRoute<YambolScreen.CreateTeam>()
+                CreateTeamScreen(
+                    isCancellable = args.isCancellable
+                ) {
                     navController.navigate(YambolScreen.Home) {
                         popUpTo(navController.graph.findStartDestination().id) {
                             inclusive = true

--- a/app/src/main/java/com/sedilant/yambol/ui/createTeam/CreateTeamScreen.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTeam/CreateTeamScreen.kt
@@ -1,5 +1,6 @@
 package com.sedilant.yambol.ui.createTeam
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -54,6 +55,7 @@ import com.sedilant.yambol.ui.theme.YambolTheme
 @Composable
 fun CreateTeamScreen(
     createTeamViewModel: CreateTeamViewModel = hiltViewModel(),
+    isCancellable: Boolean = true,
     onNavigateHome: () -> Unit
 ) {
 
@@ -73,7 +75,8 @@ fun CreateTeamScreen(
         },
         updatePlayerName = createTeamViewModel::updatePlayerName,
         updatePlayerNumber = createTeamViewModel::updatePlayerNumber,
-        playersCount = createTeamViewModel.getPlayersCount()
+        playersCount = createTeamViewModel.getPlayersCount(),
+        isCancellable = isCancellable
     )
 }
 
@@ -87,8 +90,12 @@ private fun CreateTeamScreenStateless(
     updateTeam: (String) -> Unit,
     updatePlayerName: (String) -> Unit,
     updatePlayerNumber: (String) -> Unit,
-    playersCount: Int = 0
+    playersCount: Int = 0,
+    isCancellable: Boolean = true
 ) {
+
+    // Prevent leaving setup when team creation is mandatory.
+    BackHandler(enabled = !isCancellable) { }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -113,6 +120,7 @@ private fun CreateTeamScreenStateless(
                             teamName = uiState.teamName,
                             updateTeam = updateTeam,
                             isErrorShow = uiState.isErrorMessageShow,
+                            isCancellable = isCancellable
                         )
                     }
 
@@ -127,7 +135,8 @@ private fun CreateTeamScreenStateless(
                             updatePlayerNumber = updatePlayerNumber,
                             nextButtonEnabled = uiState.isNextButtonEnabled,
                             finishButtonEnabled = uiState.isFinishButtonEnabled,
-                            playersCount = playersCount
+                            playersCount = playersCount,
+                            isCancellable = isCancellable
                         )
                     }
 
@@ -150,7 +159,8 @@ private fun AddPlayer(
     updatePlayerNumber: (String) -> Unit,
     nextButtonEnabled: Boolean,
     finishButtonEnabled: Boolean,
-    playersCount: Int
+    playersCount: Int,
+    isCancellable: Boolean
 ) {
 
     val focusRequester = remember { FocusRequester() }
@@ -269,6 +279,7 @@ private fun AddPlayer(
             onFinish = onFinish,
             onNextEnabled = nextButtonEnabled,
             onFinishEnabled = finishButtonEnabled,
+            showCancel = isCancellable
         )
     }
 }
@@ -347,7 +358,8 @@ private fun FormButtons(
     onCancel: () -> Unit,
     onFinish: () -> Unit = {},
     onNextEnabled: Boolean = true,
-    onFinishEnabled: Boolean = false
+    onFinishEnabled: Boolean = false,
+    showCancel: Boolean = true
 ) {
     Column(
         modifier = Modifier.imePadding(),
@@ -374,37 +386,47 @@ private fun FormButtons(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = if (onFinishEnabled) Arrangement.spacedBy(16.dp) else Arrangement.Center
-        ) {
-            OutlinedButton(
-                onClick = onCancel,
-                modifier = Modifier
-                    .then(if (onFinishEnabled) Modifier.weight(1f) else Modifier.fillMaxWidth())
-                    .height(56.dp),
-                shape = RoundedCornerShape(16.dp)
+        if (showCancel || onFinishEnabled) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = if (showCancel && onFinishEnabled) Arrangement.spacedBy(16.dp) else Arrangement.Center
             ) {
-                Text("Cancel")
-                Spacer(modifier = Modifier.width(8.dp))
-                Icon(
-                    imageVector = Icons.Filled.Close,
-                    contentDescription = "Cancel"
-                )
-            }
+                if (showCancel) {
+                    OutlinedButton(
+                        onClick = onCancel,
+                        modifier = Modifier
+                            .then(if (onFinishEnabled) Modifier.weight(1f) else Modifier.fillMaxWidth())
+                            .height(56.dp),
+                        shape = RoundedCornerShape(16.dp)
+                    ) {
+                        Text(stringResource(R.string.cancel))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = stringResource(R.string.cancel)
+                        )
+                    }
+                }
 
-            if (onFinishEnabled) {
-                Button(
-                    onClick = onFinish,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(56.dp),
-                    shape = RoundedCornerShape(16.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.create_team),
-                        style = MaterialTheme.typography.titleMedium
-                    )
+                if (onFinishEnabled) {
+                    Button(
+                        onClick = onFinish,
+                        modifier = if (showCancel) {
+                            Modifier
+                                .weight(1f)
+                                .height(56.dp)
+                        } else {
+                            Modifier
+                                .fillMaxWidth()
+                                .height(56.dp)
+                        },
+                        shape = RoundedCornerShape(16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.create_team),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
                 }
             }
         }
@@ -418,6 +440,7 @@ private fun AddTeamName(
     updateTeam: (String) -> Unit,
     teamName: String,
     isErrorShow: Boolean,
+    isCancellable: Boolean
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally
@@ -491,6 +514,7 @@ private fun AddTeamName(
             onNext = { onNext() },
             onCancel = onCancel,
             onNextEnabled = true,
+            showCancel = isCancellable
         )
     }
 }
@@ -508,7 +532,8 @@ private fun CreateTeamScreenAddTeamNamePreview() {
             updateTeam = {},
             updatePlayerName = {},
             updatePlayerNumber = {},
-            playersCount = 0
+            playersCount = 0,
+            isCancellable = true
         )
     }
 }
@@ -526,7 +551,8 @@ private fun CreateTeamScreenAddPlayerNamePreview() {
             updateTeam = {},
             updatePlayerName = {},
             updatePlayerNumber = {},
-            playersCount = 3
+            playersCount = 3,
+            isCancellable = true
         )
     }
 }

--- a/app/src/main/java/com/sedilant/yambol/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/home/HomeScreen.kt
@@ -49,7 +49,7 @@ import com.sedilant.yambol.ui.theme.YambolTheme
 fun HomeScreen(
     modifier: Modifier = Modifier,
     homeViewModel: HomeViewModel = hiltViewModel(),
-    onCreateTeam: () -> Unit,
+    onCreateTeam: (Boolean) -> Unit,
     onLastTrainClick: (String) -> Unit
 ) {
     val homeUiState = homeViewModel.uiState.collectAsState(
@@ -82,7 +82,7 @@ private fun HomeScreenStateless(
     homeUiState: HomeUiState,
     editTeamState: EditTeamState,
     onTeamChange: (String) -> Unit,
-    onCreateTeam: () -> Unit,
+    onCreateTeam: (Boolean) -> Unit,
     onSaveNewObjective: (String) -> Unit,
     onToggleObjectiveStatus: (String, Boolean) -> Unit,
     onUpdateObjective: (String, String, Boolean) -> Unit,
@@ -98,7 +98,7 @@ private fun HomeScreenStateless(
             // to add thing to load in future
         }
 
-        HomeUiState.CreateTeam -> onCreateTeam()
+        HomeUiState.CreateTeam -> onCreateTeam(false)
 
         is HomeUiState.Success -> {
             Column(
@@ -130,7 +130,7 @@ private fun HomeScreenStateless(
                         currentTeamId = it.id,
                         listOfTeams = homeUiState.listOfTeams,
                         onTeamChange = onTeamChange,
-                        onCreateTeam = onCreateTeam,
+                        onCreateTeam = { onCreateTeam(true) },
                         modifier = Modifier.padding(bottom = 16.dp),
                     )
                 }
@@ -440,7 +440,7 @@ private fun HomeScreenPreview() {
     YambolTheme {
         HomeScreenStateless(
             modifier = Modifier,
-            onCreateTeam = {},
+            onCreateTeam = { _ -> },
             homeUiState = HomeUiState.Success(
                 listOfTeams = listOf(TeamUiModel("Utebo", "1"), TeamUiModel("Olivar", "2")),
                 listOfPlayer = listOf(


### PR DESCRIPTION
### Description
Disable the option to navigate back when the user is creating the first team, that is mandatory in order to use the app. At least for now. 