### PR TITLE
Feature/show concepts correctly when creating a task

### DIFF
--- a/app/src/main/java/com/sedilant/yambol/data/firestore/FireStoreRepository.kt
+++ b/app/src/main/java/com/sedilant/yambol/data/firestore/FireStoreRepository.kt
@@ -503,13 +503,26 @@ class FirestoreConceptRepository(
 
     override suspend fun getConceptsByIds(userId: String, ids: List<String>): List<ConceptDto> {
         if (ids.isEmpty()) return emptyList()
+
+        val orderedIds = ids.distinct().filter { it.isNotBlank() }
+        if (orderedIds.isEmpty()) return emptyList()
+
         return try {
-            val snapshot = db.collection(FirestoreCollections.CONCEPTS)
-                .whereEqualTo(ConceptDto::userId.name, userId)
-                .whereIn(FieldPath.documentId(), ids)
-                .get()
-                .await()
-            mapDocs(snapshot, ConceptDto::class.java)
+            val conceptsById = mutableMapOf<String, ConceptDto>()
+
+            orderedIds.chunked(10).forEach { chunkIds ->
+                val snapshot = db.collection(FirestoreCollections.CONCEPTS)
+                    .whereEqualTo(ConceptDto::userId.name, userId)
+                    .whereIn(FieldPath.documentId(), chunkIds)
+                    .get()
+                    .await()
+
+                mapDocs(snapshot, ConceptDto::class.java).forEach { concept ->
+                    conceptsById[concept.id] = concept
+                }
+            }
+
+            orderedIds.mapNotNull { requestedId -> conceptsById[requestedId] }
         } catch (e: Exception) {
             emptyList()
         }

--- a/app/src/main/java/com/sedilant/yambol/ui/createTrain/commonComposables/CreateTrainScaffold.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTrain/commonComposables/CreateTrainScaffold.kt
@@ -33,6 +33,7 @@ fun CreateTrainScaffold(
     bottomButtonText: String,
     showBackButton: Boolean = false,
     onBackClick: () -> Unit = {},
+    bottomButtonEnabled: Boolean = true,
     content: @Composable (PaddingValues) -> Unit
 ) {
     Scaffold(
@@ -76,6 +77,7 @@ fun CreateTrainScaffold(
         bottomBar = {
             Button(
                 onClick = onBottomButtonClick,
+                enabled = bottomButtonEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp),

--- a/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/concepts/CreateTrainConceptsScreen.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/concepts/CreateTrainConceptsScreen.kt
@@ -76,6 +76,7 @@ private fun CreateTrainConceptsScreenStateless(
     var searchQuery by remember { mutableStateOf("") }
     var showBottomSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
+    val selectedCount = (uiState as? UiState.Success)?.concepts?.count { it.isSelected } ?: 0
 
     CreateTrainScaffold(
         title = stringResource(R.string.create_training),
@@ -84,6 +85,7 @@ private fun CreateTrainConceptsScreenStateless(
         bottomButtonText = stringResource(R.string.next),
         showBackButton = true,
         onBackClick = onBack,
+        bottomButtonEnabled = selectedCount > 0,
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -177,12 +179,18 @@ private fun CreateTrainConceptsScreenStateless(
 
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    val selectedCount = uiState.concepts.count { it.isSelected }
                     if (selectedCount > 0) {
                         Text(
                             text = stringResource(R.string.concepts_selected, selectedCount),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.error_concepts_required_to_continue),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error,
                             modifier = Modifier.padding(bottom = 8.dp)
                         )
                     }

--- a/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/AddTaskBottomSheet.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/AddTaskBottomSheet.kt
@@ -49,7 +49,8 @@ import com.sedilant.yambol.ui.createTrain.stepsScreens.concepts.Concept
 internal fun AddTaskBottomSheet(
     onAddTask: (name: String, description: String, concepts: List<String>, variants: List<String>) -> Unit,
     onDismiss: () -> Unit,
-    concepts: List<Concept> // These are all available concepts in the database
+    concepts: List<Concept>,
+    conceptsError: String? = null
 ) {
     var taskName by remember { mutableStateOf("") }
     var taskDescription by remember { mutableStateOf("") }
@@ -139,6 +140,15 @@ internal fun AddTaskBottomSheet(
             }
         }
 
+        conceptsError?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = it,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
         Spacer(modifier = Modifier.height(16.dp))
 
         // Variants Section
@@ -187,10 +197,9 @@ internal fun AddTaskBottomSheet(
                         selectedConceptIds.toList(),
                         taskVariants.filter { it.isNotBlank() }.toList()
                     )
-                    onDismiss()
                 },
                 modifier = Modifier.weight(1f),
-                enabled = taskName.isNotBlank()
+                enabled = taskName.isNotBlank() && selectedConceptIds.isNotEmpty()
             ) {
                 Text("Guardar")
             }
@@ -213,11 +222,12 @@ private fun AddTaskBottomSheetPreview() {
     MaterialTheme {
         Surface {
             AddTaskBottomSheet(
-                onAddTask = { name, desc, conceptIds, variants ->
+                onAddTask = { _, _, _, _ ->
                     // No action needed for preview
                 },
                 onDismiss = {},
-                concepts = mockConcepts
+                concepts = mockConcepts,
+                conceptsError = null
             )
         }
     }

--- a/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/CreateTrainTasksScreen.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/CreateTrainTasksScreen.kt
@@ -55,10 +55,11 @@ fun CreateTrainTasksScreen(
         onAddTask = viewModel::onAddTask,
         onDeleteTask = viewModel::onDeleteTask,
         onBack = onBack,
-        onNext = onNext, // saveStepData removed as it's now reactive
+        onNext = onNext,
         onClose = onClose,
         onClearError = viewModel::clearError,
-        onTaskSelected = viewModel::onTaskSelected
+        onTaskSelected = viewModel::onTaskSelected,
+        onClearTaskConceptError = viewModel::clearTaskConceptError
     )
 }
 
@@ -73,7 +74,8 @@ private fun CreateTrainTasksScreenStateless(
     onMove: (from: Int, to: Int) -> Unit,
     onAddTask: (name: String, description: String, variation: List<String>, concepts: List<String>) -> Unit,
     onTaskSelected: (TaskUI) -> Unit,
-    onDeleteTask: (taskId: String) -> Unit
+    onDeleteTask: (taskId: String) -> Unit,
+    onClearTaskConceptError: () -> Unit
 ) {
     var showCreateTaskBottomSheet by remember { mutableStateOf(false) }
     var showExistingTasksBottomSheet by remember { mutableStateOf(false) }
@@ -121,16 +123,18 @@ private fun CreateTrainTasksScreenStateless(
 
                     AddTaskButton(onClick = { showCreateTaskBottomSheet = true })
 
-                    OutlinedButton(
-                        onClick = { showExistingTasksBottomSheet = true },
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .fillMaxWidth()
-                            .height(40.dp)
-                    ) {
-                        Icon(imageVector = Icons.Default.Add, contentDescription = null)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = stringResource(R.string.add_existing_exercise))
+                    if (uiState.existingTasks.isNotEmpty()) {
+                        OutlinedButton(
+                            onClick = { showExistingTasksBottomSheet = true },
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                                .fillMaxWidth()
+                                .height(40.dp)
+                        ) {
+                            Icon(imageVector = Icons.Default.Add, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(text = stringResource(R.string.add_existing_exercise))
+                        }
                     }
 
                     if (uiState.draftTasks.isNotEmpty()) {
@@ -156,16 +160,29 @@ private fun CreateTrainTasksScreenStateless(
                     // Bottom Sheet Logic
                     if (showCreateTaskBottomSheet) {
                         ModalBottomSheet(
-                            onDismissRequest = { showCreateTaskBottomSheet = false },
+                            onDismissRequest = {
+                                showCreateTaskBottomSheet = false
+                                onClearTaskConceptError()
+                            },
                             sheetState = sheetState
                         ) {
                             AddTaskBottomSheet(
                                 onAddTask = { name, description, concepts, variation ->
                                     onAddTask(name, description, variation, concepts)
-                                    showCreateTaskBottomSheet = false
+                                    if (concepts.isNotEmpty()) {
+                                        showCreateTaskBottomSheet = false
+                                    }
                                 },
-                                onDismiss = { showCreateTaskBottomSheet = false },
+                                onDismiss = {
+                                    showCreateTaskBottomSheet = false
+                                    onClearTaskConceptError()
+                                },
                                 concepts = uiState.listOfConcept,
+                                conceptsError = if (uiState.taskConceptError == "TASK_CONCEPT_REQUIRED") {
+                                    stringResource(R.string.error_task_concept_required)
+                                } else {
+                                    null
+                                }
                             )
                         }
                     }
@@ -195,7 +212,7 @@ private fun CreateTrainTasksScreenStateless(
 private fun AddTaskButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     Button(
         onClick = onClick,
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .height(64.dp)
             .padding(horizontal = 16.dp),

--- a/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/CreateTrainTasksViewModel.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/createTrain/stepsScreens/tasks/CreateTrainTasksViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.sedilant.yambol.data.draftTrain.Task
 import com.sedilant.yambol.data.draftTrain.TrainingDraftRepository
 import com.sedilant.yambol.data.firebaseAuth.AuthRepository
+import com.sedilant.yambol.data.firestore.ConceptDto
 import com.sedilant.yambol.data.firestore.ConceptRepository
 import com.sedilant.yambol.domain.get.GetAllTaskUseCase
+import com.sedilant.yambol.domain.models.TaskDomain
 import com.sedilant.yambol.ui.createTrain.stepsScreens.concepts.Concept
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,6 +40,7 @@ class CreateTrainTasksViewModel @Inject constructor(
 
     // Internal flow for transient errors (like failed network/db operations)
     private val _manualError = MutableStateFlow<String?>(null)
+    private val _taskConceptError = MutableStateFlow<String?>(null)
 
     val uiState: StateFlow<UiStateNew> = _draftId
         .filterNotNull()
@@ -50,69 +53,21 @@ class CreateTrainTasksViewModel @Inject constructor(
                     combine(
                         draftRepository.observeDraft(id),
                         _manualError,
+                        _taskConceptError,
                         getAllTaskUseCase()
-                    ) { draft, manualError, existingTasksList ->
+                    ) { draft, manualError, conceptError, existingTasksList ->
                         when {
                             manualError != null -> UiStateNew.Error(manualError)
-                            draft != null -> {
-                        // Async fetch for concepts
-                val conceptIds =
-                    (draft.tasks.flatMap { it.concepts } + draft.conceptIds + existingTasksList.flatMap { it.concepts })
-                        .distinct()
-                        .filter { it.isNotBlank() }
-                        val conceptsMap =
-                            conceptsRepository.getConceptsByIds(userId = userId, ids = conceptIds)
-                        UiStateNew.Success(
-                            draftTasks = draft.tasks.map { task ->
-                                TaskUI(
-                                    id = task.id,
-                                    name = task.name,
-                                    concepts = conceptsMap.filter { task.concepts.contains(it.id) }
-                                        .map {
-                                            Concept(
-                                                id = it.id,
-                                                conceptName = it.name,
-                                            )
-                                        },
-                                    description = task.description,
-                                    variation = task.variation,
-                                    duration = "0"
-                                )
-                            },
-                            listOfConcept = conceptsMap
-                                .map {
-                                    Concept(
-                                        id = it.id,
-                                        conceptName = it.name,
-                                    )
-                                },
-                            existingTasks = existingTasksList.map { existingTask ->
-                                TaskUI(
-                                    id = existingTask.trainingTaskId,
-                                    name = existingTask.name,
-                                    concepts = conceptsMap.filter {
-                                        existingTask.concepts.contains(
-                                            it.id
-                                        )
-                                    }
-                                        .map {
-                                            Concept(
-                                                id = it.id,
-                                                conceptName = it.name,
-                                            )
-                                        },
-                                    description = existingTask.description,
-                                    variation = existingTask.variables.sorted()
-                                        .joinToString(","),
-                                    duration = "0"
-                                )
-                            }
-                        )
+                            draft == null -> UiStateNew.Error("No se pudo encontrar el borrador")
+                            else -> buildSuccessState(
+                                userId = userId,
+                                draftTasks = draft.tasks,
+                                selectedDraftConceptIds = draft.conceptIds,
+                                existingTasksList = existingTasksList,
+                                conceptError = conceptError
+                            )
+                        }
                     }
-
-                    else -> UiStateNew.Error("No se pudo encontrar el borrador")
-                }
-            }
                 }
             }
         }
@@ -124,6 +79,57 @@ class CreateTrainTasksViewModel @Inject constructor(
 
     init {
         loadInitialData()
+    }
+
+    private suspend fun buildSuccessState(
+        userId: String,
+        draftTasks: List<Task>,
+        selectedDraftConceptIds: List<String>,
+        existingTasksList: List<TaskDomain>,
+        conceptError: String?
+    ): UiStateNew.Success {
+        val selectedConceptIds = selectedDraftConceptIds.distinct().filter { it.isNotBlank() }
+        val selectedConceptSet = selectedConceptIds.toSet()
+
+        val selectedConceptDtos = conceptsRepository.getConceptsByIds(userId = userId, ids = selectedConceptIds)
+        val selectedConceptById = selectedConceptDtos.associateBy { it.id }
+        val selectedConcepts = selectedConceptIds.mapNotNull { conceptId ->
+            selectedConceptById[conceptId]?.toUiConcept()
+        }
+
+        val filteredExistingTasks = if (selectedConceptSet.isEmpty()) {
+            emptyList()
+        } else {
+            existingTasksList.filter { existingTask ->
+                existingTask.concepts.any(selectedConceptSet::contains)
+            }
+        }
+
+        val taskConceptIds = (draftTasks.flatMap { it.concepts } + filteredExistingTasks.flatMap { it.concepts })
+            .distinct()
+            .filter { it.isNotBlank() }
+        val taskConceptById = conceptsRepository.getConceptsByIds(userId = userId, ids = taskConceptIds)
+            .associateBy { it.id }
+
+        val conceptById = taskConceptById + selectedConceptById
+
+        return UiStateNew.Success(
+            draftTasks = draftTasks.map { task -> task.toTaskUi(conceptById) },
+            listOfConcept = selectedConcepts,
+            existingTasks = filteredExistingTasks.map { existingTask ->
+                TaskUI(
+                    id = existingTask.trainingTaskId,
+                    name = existingTask.name,
+                    concepts = existingTask.concepts.mapNotNull { conceptId ->
+                        conceptById[conceptId]?.toUiConcept()
+                    },
+                    description = existingTask.description,
+                    variation = existingTask.variables.sorted().joinToString(","),
+                    duration = "0"
+                )
+            },
+            taskConceptError = conceptError
+        )
     }
 
     private fun loadInitialData() {
@@ -150,11 +156,18 @@ class CreateTrainTasksViewModel @Inject constructor(
         val id = _draftId.value ?: return
         if (name.isBlank()) return
 
+        val sanitizedConcepts = concepts.distinct().filter { it.isNotBlank() }
+        if (sanitizedConcepts.isEmpty()) {
+            _taskConceptError.value = "TASK_CONCEPT_REQUIRED"
+            return
+        }
+
         viewModelScope.launch {
             try {
+                _taskConceptError.value = null
                 val newTask = Task(
                     name = name.trim(),
-                    concepts = concepts,
+                    concepts = sanitizedConcepts,
                     description = description.trim(),
                     variation = variation.toCommaSeparatedString().trim(),
                 )
@@ -169,12 +182,19 @@ class CreateTrainTasksViewModel @Inject constructor(
         val id = _draftId.value ?: return
         if (task.name.isBlank()) return
 
+        val selectedConcepts = task.concepts.map { it.id }.distinct().filter { it.isNotBlank() }
+        if (selectedConcepts.isEmpty()) {
+            _taskConceptError.value = "TASK_CONCEPT_REQUIRED"
+            return
+        }
+
         viewModelScope.launch {
             try {
+                _taskConceptError.value = null
                 val newTask = Task(
                     id = task.id,
                     name = task.name.trim(),
-                    concepts = task.concepts.map { it.id },
+                    concepts = selectedConcepts,
                     description = task.description.trim(),
                     variation = task.variation,
                 )
@@ -209,13 +229,11 @@ class CreateTrainTasksViewModel @Inject constructor(
     private fun saveTasksOrder(id: String, tasks: List<TaskUI>) {
         viewModelScope.launch {
             try {
-                // Re-mapping UI tasks back to Domain Tasks for the repository
                 val domainTasks = tasks.map { taskUI ->
                     Task(
                         id = taskUI.id,
                         name = taskUI.name,
-                        // Note: You might need to preserve concept IDs here
-                        concepts = emptyList(), // TODO preserve the concepts here
+                        concepts = taskUI.concepts.map { it.id },
                         description = taskUI.description,
                         variation = taskUI.variation
                     )
@@ -245,11 +263,16 @@ class CreateTrainTasksViewModel @Inject constructor(
         _manualError.value = null
     }
 
+    fun clearTaskConceptError() {
+        _taskConceptError.value = null
+    }
+
     sealed interface UiStateNew {
         data class Success(
             val draftTasks: List<TaskUI>,
             val listOfConcept: List<Concept>,
-            val existingTasks: List<TaskUI>
+            val existingTasks: List<TaskUI>,
+            val taskConceptError: String? = null
         ) : UiStateNew
 
         data class Error(val message: String) : UiStateNew
@@ -258,3 +281,19 @@ class CreateTrainTasksViewModel @Inject constructor(
 }
 
 private fun List<String>.toCommaSeparatedString(): String = joinToString(",")
+
+private fun ConceptDto.toUiConcept(): Concept = Concept(
+    id = id,
+    conceptName = name
+)
+
+private fun Task.toTaskUi(conceptById: Map<String, ConceptDto>): TaskUI = TaskUI(
+    id = id,
+    name = name,
+    concepts = concepts.mapNotNull { conceptId ->
+        conceptById[conceptId]?.toUiConcept()
+    },
+    description = description,
+    variation = variation,
+    duration = "0"
+)

--- a/app/src/main/java/com/sedilant/yambol/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/home/HomeViewModel.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Locale
@@ -69,6 +71,7 @@ class HomeViewModel @Inject constructor(
             currentTeamFlow.update { newTeamId }
             dataStoreManager.saveCurrentTeam(newTeamId)
             lastTrainId = getLastTrainOfTeamUseCase(newTeamId)
+            refreshData()
         }
     }
 
@@ -151,30 +154,15 @@ class HomeViewModel @Inject constructor(
 
     private fun setupUiStateFlow() {
         viewModelScope.launch {
-            trigger.flatMapLatest { _ ->
-                val teamsFlow = getTeamsUseCase()
+            trigger.flatMapLatest {
                 combine(
-                    teamsFlow,
-                    currentTeamFlow.flatMapLatest { teamId ->
-                        if (teamId != null) {
-                            getPlayersByTeamIdUseCase(teamId)
-                        } else {
-                            MutableStateFlow(emptyList())
-                        }
-                    },
-                    currentTeamFlow.flatMapLatest { teamId ->
-                        if (teamId != null) {
-                            getTeamObjectivesUseCase(teamId)
-                        } else {
-                            MutableStateFlow(emptyList())
-                        }
-                    },
-                    currentTeamFlow,
-                ) { teams, teamPlayerList, teamObjectivesList, currentTeamId ->
-
-                    // If there are no teams, navigate to CreateTeamScreen
+                    getTeamsUseCase(),
+                    currentTeamFlow
+                ) { teams, requestedTeamId ->
+                    teams to requestedTeamId
+                }.flatMapLatest { (teams, requestedTeamId) ->
                     if (teams.isEmpty()) {
-                        return@combine HomeUiState.CreateTeam
+                        return@flatMapLatest flowOf(HomeUiState.CreateTeam)
                     }
 
                     val listOfTeams = teams.map { team ->
@@ -186,35 +174,37 @@ class HomeViewModel @Inject constructor(
                         )
                     }
 
-                    // TODO remove this part because we already do it in the loadSavedTeam
-                    // If currentTeamId is null but there are teams, use the first one
-                    val safeCurrentTeamId = currentTeamId ?: if (listOfTeams.isNotEmpty()) {
-                        val firstTeamId = listOfTeams.first().id
-                        // Update the new actual team
-                        viewModelScope.launch {
-                            currentTeamFlow.update { firstTeamId }
-                            dataStoreManager.saveCurrentTeam(firstTeamId)
+                    val resolvedTeamId = teams.firstOrNull { it.id == requestedTeamId }?.id
+                        ?: teams.first().id
+
+                    flow {
+                        // Keep in-memory and persisted selection aligned to a valid team.
+                        if (requestedTeamId != resolvedTeamId) {
+                            currentTeamFlow.update { resolvedTeamId }
+                            dataStoreManager.saveCurrentTeam(resolvedTeamId)
                         }
-                        firstTeamId
-                    } else null
-
-                    if (safeCurrentTeamId == null) {
-                        return@combine HomeUiState.Loading
-                    }
-
-                    HomeUiState.Success(
-                        listOfTeams = listOfTeams,
-                        currentTeam = listOfTeams.find { it.id == safeCurrentTeamId },
-                        listOfPlayer = teamPlayerList,
-                        listOfObjectives = teamObjectivesList.map {
-                            TeamObjectivesUiModel(
-                                description = it.description,
-                                isFinish = it.isFinish,
-                                id = it.id,
+                        lastTrainId = getLastTrainOfTeamUseCase(resolvedTeamId)
+                        emit(resolvedTeamId to listOfTeams)
+                    }.flatMapLatest { (teamId, uiTeams) ->
+                        combine(
+                            getPlayersByTeamIdUseCase(teamId),
+                            getTeamObjectivesUseCase(teamId)
+                        ) { teamPlayerList, teamObjectivesList ->
+                            HomeUiState.Success(
+                                listOfTeams = uiTeams,
+                                currentTeam = uiTeams.first { it.id == teamId },
+                                listOfPlayer = teamPlayerList,
+                                listOfObjectives = teamObjectivesList.map {
+                                    TeamObjectivesUiModel(
+                                        description = it.description,
+                                        isFinish = it.isFinish,
+                                        id = it.id,
+                                    )
+                                },
+                                lastTrainId = lastTrainId
                             )
-                        },
-                        lastTrainId = lastTrainId
-                    )
+                        }
+                    }
                 }
             }.collect { state ->
                 _uiState.value = state
@@ -227,23 +217,22 @@ class HomeViewModel @Inject constructor(
             try {
                 _uiState.value = HomeUiState.Loading
 
-                val savedTeamId = dataStoreManager.currentTeam.first()
-                if (savedTeamId != null) {
-                    currentTeamFlow.update { savedTeamId }
-                    lastTrainId = getLastTrainOfTeamUseCase(savedTeamId)
-                } else {
-                    val teams = getTeamsUseCase().first()
-
-                    if (teams.isEmpty()) {
-                        _uiState.value = HomeUiState.CreateTeam
-                        return@launch
-                    } else {
-                        val firstTeamId = teams.first().id
-                        currentTeamFlow.update { firstTeamId }
-                        lastTrainId = getLastTrainOfTeamUseCase(savedTeamId)
-                        dataStoreManager.saveCurrentTeam(firstTeamId)
-                    }
+                val teams = getTeamsUseCase().first()
+                if (teams.isEmpty()) {
+                    currentTeamFlow.update { null }
+                    dataStoreManager.saveCurrentTeam(null)
+                    _uiState.value = HomeUiState.CreateTeam
+                    return@launch
                 }
+
+                val savedTeamId = dataStoreManager.currentTeam.first()
+                val resolvedTeamId = teams.firstOrNull { it.id == savedTeamId }?.id ?: teams.first().id
+
+                currentTeamFlow.update { resolvedTeamId }
+                if (savedTeamId != resolvedTeamId) {
+                    dataStoreManager.saveCurrentTeam(resolvedTeamId)
+                }
+                lastTrainId = getLastTrainOfTeamUseCase(resolvedTeamId)
             } finally {
                 refreshData()
             }

--- a/app/src/main/java/com/sedilant/yambol/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/sedilant/yambol/ui/profile/ProfileViewModel.kt
@@ -2,6 +2,7 @@ package com.sedilant.yambol.ui.profile
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sedilant.yambol.data.DataStoreManager
 import com.sedilant.yambol.data.firebaseAuth.AuthRepository
 import com.sedilant.yambol.data.firebaseAuth.AuthResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +35,8 @@ sealed class ProfileUiState {
  */
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val dataStoreManager: DataStoreManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<ProfileUiState>(ProfileUiState.Loading)
@@ -74,6 +76,7 @@ class ProfileViewModel @Inject constructor(
     fun signOut() {
         viewModelScope.launch {
             _uiState.update { ProfileUiState.Loading }
+            dataStoreManager.saveCurrentTeam(null)
             authRepository.signOut()
         }
     }
@@ -94,6 +97,7 @@ class ProfileViewModel @Inject constructor(
 
             when (val result = authRepository.deleteAccount()) {
                 is AuthResult.Success -> {
+                    dataStoreManager.saveCurrentTeam(null)
                     // observeAuthState will handle the transition
                 }
                 is AuthResult.Error -> {

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -94,6 +94,10 @@
     <string name="variation_label">Variación: %s</string>
     <string name="variables_help_text">Las variables te ayudan a rastrear y modificar la tarea durante el entrenamiento</string>
 
+    <!-- Training - Validation -->
+    <string name="error_concepts_required_to_continue">Selecciona al menos un concepto para continuar.</string>
+    <string name="error_task_concept_required">Selecciona al menos un concepto para la tarea.</string>
+
     <!-- Training - Details & Review -->
     <string name="add_specific_tasks_and_drills_for_this_training_optional">Añade tareas y ejercicios específicos para este entrenamiento (opcional)</string>
     <string name="no_tasks_added">No se han añadido tareas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="variation_label">Variation: %s</string>
     <string name="variables_help_text">Variables help you track and modify the task during training</string>
 
+    <!-- Training - Validation -->
+    <string name="error_concepts_required_to_continue">Select at least one concept to continue.</string>
+    <string name="error_task_concept_required">Select at least one concept for the task.</string>
+
     <!-- Training - Details & Review -->
     <string name="add_specific_tasks_and_drills_for_this_training_optional">Add specific tasks and drills for this training (optional)</string>
     <string name="no_tasks_added">No tasks added</string>


### PR DESCRIPTION
## Summary

This PR fixes concept display when creating a task and adds validation to prevent proceeding without selecting at least one concept.

## Changes

### Bug Fixes
- **Firestore concept fetching**: Refactored `getConceptsById` to handle Firestore's 10-item `whereIn` limit by chunking IDs and merging results. Also added deduplication and blank ID filtering.
- **Concept data consistency**: Moved concept fetching logic out of the ViewModel's combine block and introduced a dedicated `buildSuccessState` helper to simplify state construction.

### New Features
- **Concept validation**: Added `TASK_CONCEPT_REQUIRED` error handling — the "Next" button on the concepts screen is now disabled until at least one concept is selected, and an error message is shown when none are selected.
- **Task concept error**: Added `conceptsError` parameter to `AddTaskBottSheet` to display inline error messages when no concept is selected for a task.
- **Save button validation**: The save button in `AddTaskBottomSheet` now requires both a non-blank task name **and** at least one selected concept to be enabled.

### Refactors
- Added `bottomButtonEnabled` parameter to `CreateTrainScaffold` for external control of the bottom action button state.
- Added `onClearTaskConceptError` callback to clear concept errors on dismiss.
- "Add existing exercise" button is now conditionally shown only when existing tasks are available.
- Removed inline `saveStepData` call (now reactive).